### PR TITLE
Add readme and add collapsible "full context" sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 resources/
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Prometheus-Operator Runbooks
+
+This repo contains the official [runbooks](https://en.wikipedia.org/wiki/Runbook) for the various alerts sent out by components of the prometheus-operator ecosystem.
+
+The live version can be found at https://runbooks.prometheus-operator.dev/
+
+## Contributing
+
+To edit or expand an existing runbook, feel free to edit the files under `content/` and submit a pull request.
+
+To create a new runbook, see [add-runbook.md](./content/docs/add-runbook.md)

--- a/README.md
+++ b/README.md
@@ -8,4 +8,11 @@ The live version can be found at https://runbooks.prometheus-operator.dev/
 
 To edit or expand an existing runbook, feel free to edit the files under `content/` and submit a pull request.
 
-To create a new runbook, see [add-runbook.md](./content/docs/add-runbook.md)
+To create a new runbook, see [add-runbook.md](./content/docs/add-runbook.md).
+
+
+## Guidelines
+
+The purpose of this repository is to have a documentation about every alert shipped by kube-prometheus (not only by prometheus-operator). In the long run, we are aiming to support as many k8s flavors as possible. If possible try to ensure the 'Diagnosis/Mitigation' sections are applicable to all certified kubernetes distributions.
+
+The primary target for these runbooks are folks who are novices and don't have much insight into what to do with alerts shipped in kube-prometheus. As a result, try to avoid excessive jargon and abbreviations.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,4 @@ This repo contains the official [runbooks](https://en.wikipedia.org/wiki/Runbook
 
 The live version can be found at https://runbooks.prometheus-operator.dev/
 
-## Contributing
-
-To edit or expand an existing runbook, feel free to edit the files under `content/` and submit a pull request.
-
-To create a new runbook, see [add-runbook.md](./content/docs/add-runbook.md).
-
-
-## Guidelines
-
-The purpose of this repository is to have a documentation about every alert shipped by kube-prometheus (not only by prometheus-operator). In the long run, we are aiming to support as many k8s flavors as possible. If possible try to ensure the 'Diagnosis/Mitigation' sections are applicable to all certified kubernetes distributions.
-
-The primary target for these runbooks are folks who are novices and don't have much insight into what to do with alerts shipped in kube-prometheus. As a result, try to avoid excessive jargon and abbreviations.
+For information about contributing, see [add-runbook.md](./content/docs/add-runbook.md).

--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,8 @@ params:
   BookSection: "runbooks"
   #BookMenuBundle: "/menu"
 
+markup:
+  goldmark:
+    renderer:
+      # Allows rendering HTML tags. This would only be truly "unsafe" if we were accepting untrusted user input and rendering it, which we aren't.
+      unsafe: true

--- a/content/docs/add-runbook.md
+++ b/content/docs/add-runbook.md
@@ -44,6 +44,15 @@ Runbook example based on a NodeFilesystemSpaceFillingUp (thanks to @beorn7):
 
 This alert is based on an extrapolation of the space used in a file system. It fires if both the current usage is above a certain threshold _and_ the extrapolation predicts to run out of space in a certain time. This is a warning-level alert if that time is less than 24h. It's a critical alert if that time is less than 4h.
 
+<details>
+<summary>Full context</summary>
+
+Here is where you can optionally describe some more details about the alert. The "meaning" is the short version for an on-call engineer to quickly read through. The "details" are for learning about the bigger picture or the finer details.
+
+> NOTE: The blank lines above and below the text inside this `<details>` tag are [required to use markdown inside of html tags][1]
+
+</details>
+
 ## Impact
 
 A filesystem running completely full is obviously very bad for any process in need to write to the filesystem. But even before a filesystem runs completely full, performance is usually degrading.
@@ -59,4 +68,7 @@ Is this some irregular condition, e.g. a process fails to clean up behind itself
 ## Mitigation
 
 <Insert site specific measures, for example to grow a persistent volume.>
+
+
+[1]: https://github.github.com/gfm/#html-block
 ```

--- a/content/docs/add-runbook.md
+++ b/content/docs/add-runbook.md
@@ -72,3 +72,17 @@ Is this some irregular condition, e.g. a process fails to clean up behind itself
 
 [1]: https://github.github.com/gfm/#html-block
 ```
+
+### Guidelines
+
+The purpose of this repository is to have a documentation about every alert shipped by kube-prometheus (not only by prometheus-operator). In the long run, we are aiming to support as many k8s flavors as possible. If possible try to ensure the 'Diagnosis/Mitigation' sections are applicable to all certified kubernetes distributions.
+
+The primary target for these runbooks are folks who are novices and don't have much insight into what to do with alerts shipped in kube-prometheus. As a result, try to avoid excessive jargon and abbreviations.
+
+### Testing locally
+
+To test your changes locally:
+
+1. Install [Hugo](https://gohugo.io/getting-started/installing/)
+2. Run `git submodule init` and `git submodule update` to clone the Hugo theme
+3. Run `hugo server` and navigate to http://localhost:1313/ in your browser

--- a/content/runbooks/etcd/etcdHighFsyncDurations.md
+++ b/content/runbooks/etcd/etcdHighFsyncDurations.md
@@ -5,6 +5,15 @@
 This alert fires when the 99th percentile of etcd disk fsync duration is too
 high for 10 minutes.
 
+<details>
+<summary>Full context</summary>
+
+Every write request sent to etcd has to be [fsync'd][fsync] to disk by the leader node, transmitted to its peers, and fsync'd to those disks as well before etcd can tell the client that the write request succeeded (as part of the [Raft consensus algorithm][raft]). As a result of all those fsync's, etcd cares a LOT about disk latency, which this alert picks up on.
+
+Etcd instances perform poorly on network-attached storage. Directly-attached spinning disks may work, but solid-state disks or better [are recommended][etcd-disks] for larger clusters. For very large clusters, you may even consider a [separate etcd cluster just for events][etcd-events] to reduce the write load.
+
+</details>
+
 ## Impact
 
 When this happens it can lead to various scenarios like leader election failure,
@@ -51,5 +60,9 @@ above. More space should be available now.
 Further info on etcd best practices can be found in the [OpenShift docs
 here][etcdPractices].
 
+[fsync]: https://man7.org/linux/man-pages/man2/fsync.2.html
+[raft]: https://en.wikipedia.org/wiki/Raft_(algorithm)#Log_replication
+[etcd-disks]: https://etcd.io/docs/v3.5/op-guide/hardware/#disks
+[etcd-events]: https://github.com/kubernetes/kubernetes/issues/4432
 [etcdDefragmentation]: https://etcd.io/docs/v3.4.0/op-guide/maintenance/
 [etcdPractices]: https://docs.openshift.com/container-platform/4.7/scalability_and_performance/recommended-host-practices.html#recommended-etcd-practices_

--- a/content/runbooks/general/TargetDown.md
+++ b/content/runbooks/general/TargetDown.md
@@ -4,6 +4,13 @@
 
 The alert means that one or more prometheus scrape targets are down. It fires when at least 10% of scrape targets in a Service are unreachable.
 
+<details>
+<summary>Full context</summary>
+
+Prometheus works by sending an HTTP GET request to all of its "targets" every few seconds. So TargetDown really means that Prometheus just can't access your service, which may or may not mean it's actually down. If your service appears to be running fine, a common cause could be a misconfigured ServiceMonitor (maybe the port or path is incorrect), a misconfigured NetworkPolicy, or Service with incorrect labelSelectors that isn't selecting any Pods.
+
+</details>
+
 ## Impact
 
 Metrics from a particular target cannot be scraped as such there is no data for this target in Prometheus and alerting can be hindered.

--- a/content/runbooks/kubernetes/KubeAPIErrorBudgetBurn.md
+++ b/content/runbooks/kubernetes/KubeAPIErrorBudgetBurn.md
@@ -2,16 +2,25 @@
 
 ## Impact
 
-The overall availability of your Kubernetes cluster isn't guaranteed anymore.  
+The overall availability of your Kubernetes cluster isn't guaranteed anymore.
 There may be **too many errors** returned by the APIServer and/or **responses take too long** for guarantee proper reconciliation.
 
 **This is always important; the only deciding factor is how urgent it is at the current rate**
+
+<details>
+<summary>Full context</summary>
+
+This alert essentially means that a higher-than-expected percentage of the operations kube-apiserver is performing are erroring. Since random errors are inevitable, kube-apiserver has a "budget" of errors that it is allowed to make before triggering this alert.
+
+Learn more about Multiple Burn Rate Alerts in the [SRE Workbook Chapter 5](https://sre.google/workbook/alerting-on-slos/#recommended_time_windows_and_burn_rates_f).
+
+</details>
 
 ## Critical
 
 First check the labels `long` and `short`.
 
-* `long: 1h` and `short: 5m`: less than **~2 days** -- You should fix the problem as soon as possible!  
+* `long: 1h` and `short: 5m`: less than **~2 days** -- You should fix the problem as soon as possible!
 * `long: 6h` and `short: 30m`: less than **~5 days** -- Track this down now but no immediate fix required.
 
 ## Warning
@@ -19,7 +28,7 @@ First check the labels `long` and `short`.
 First check the labels `long` and `short`.
 
 * `long: 1d` and `short: 2h`: less than **~10 days** -- This is problematic in the long run. You should take a look in the next 24-48 hours.
-* `long: 3d` and `short: 6h`: less than **~30 days** -- (the entire window of the error budget) at this rate. This means that at the end of the next 30 days there won't be any error budget left at this rate. It's fine to leave this over the weekend and have someone take a look in the coming days at working hours.  
+* `long: 3d` and `short: 6h`: less than **~30 days** -- (the entire window of the error budget) at this rate. This means that at the end of the next 30 days there won't be any error budget left at this rate. It's fine to leave this over the weekend and have someone take a look in the coming days at working hours.
 
 _Example: If you have a 99% availability target this means that at the end of 30 days you're going to be below 99% at this rate._
 
@@ -29,13 +38,14 @@ _Example: If you have a 99% availability target this means that at the end of 30
     1. At the very top check your current availability and how much percent of error budget is left. This should indicate the severity too.
     1. Do you see an elevated error rate in reads or writes?
     1. Do you see too many slow requests in reads or writes?
+1. Check the logs for kube-apiserver using the following Loki query: `{component="kube-apiserver"}`
 1. Run debugging queries in Prometheus or Grafana Explore to dig deeper.
     1. If you don't see anything obvious with the error rates, it might be too many slow requests. [Check the queries below!](#example-queries-for-slow-requests)
 1. Maybe it's some dependency of the APIServer? etcd?
 
 ### Example Queries for slow requests:
 
-Change the rate window according to your `long` label from the alert.  
+Change the rate window according to your `long` label from the alert.
 Make sure to update the alert threshold too, like `> 0.01` to `> 14.4 * 0.01` for example.
 #### Slow Read Requests:
 
@@ -46,7 +56,7 @@ Cluster scoped:
 ```
 (
 sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="40",scope="cluster",verb=~"LIST|GET"}[3d]))
-- 
+-
 sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[3d]))
 )
 /
@@ -57,7 +67,7 @@ Namespace scoped:
 ```
 (
 sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="5",scope="namespace",verb=~"LIST|GET"}[3d]))
-- 
+-
 sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[3d]))
 )
 /
@@ -69,7 +79,7 @@ Resource scoped:
 ```
 (
 sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="1",scope=~"resource|",verb=~"LIST|GET"}[3d])) or vector(0)
-- 
+-
 sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[3d]))
 )
 /
@@ -89,6 +99,3 @@ sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="1",verb=~
 sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
 > 0.01
 ```
-
---- 
-Learn more about Multiple Burn Rate Alerts in the [SRE Workbook Chapter 5](https://sre.google/workbook/alerting-on-slos/#recommended_time_windows_and_burn_rates_f).

--- a/content/runbooks/kubernetes/KubeletTooManyPods.md
+++ b/content/runbooks/kubernetes/KubeletTooManyPods.md
@@ -1,5 +1,27 @@
 # KubeletTooManyPods
 
-The Kubelet in a Kubernetes cluster is the agent that ensures Pods are running on that host.
 
-Kubelet's have a configuration that limits how many Pods they can run. The default value of this is 110 Pods per Kubelet, but it is configurable (and this alert takes that configuration into account with the `kube_node_status_capacity_pods` metric). The alert fires when a Kubelet reaches 95% of its capacity. This alert warns about the likelihood that the cluster is close to running out of capacity to run Pods on the cluster. Either the cluster must be increased in its node count, or the number of Pods must be reduced.
+## Meaning
+
+The alert fires when a specific node is running >95% of its capacity of pods (110 by default).
+
+<details>
+<summary>Full context</summary>
+
+Kubelets have a configuration that limits how many Pods they can run. The default value of this is 110 Pods per Kubelet, but it is configurable (and this alert takes that configuration into account with the `kube_node_status_capacity_pods` metric).
+
+</details>
+
+## Impact
+
+Running many pods (more than 110) on a single node places a strain on the Container Runtime Interface (CRI), Container Network Interface (CNI), and the operating system itself. Approaching that limit may affect performance and availability of that node.
+
+## Diagnosis
+
+Check the number of pods on a given node by running `kubectl get pods --all-namespaces --field-selector spec.nodeName=<node>`
+
+## Mitigation
+
+Since Kubernetes only officially supports [110 pods per node](https://kubernetes.io/docs/setup/best-practices/cluster-large/), you should preferably move pods onto other nodes or expand your cluster with more worker nodes.
+
+If you're certain the node can handle more pods, you can raise the max pods per node limit by changing `maxPods` in your [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/) (for kubeadm-based clusters) or changing the setting in your cloud provider's dashboard (if supported).

--- a/content/runbooks/node/NodeFilesystemSpaceFillingUp.md
+++ b/content/runbooks/node/NodeFilesystemSpaceFillingUp.md
@@ -8,6 +8,14 @@ extrapolation predicts to run out of space in a certain time. This is a
 warning-level alert if that time is less than 24h. It's a critical alert if that
 time is less than 4h.
 
+<details>
+<summary>Full context</summary>
+
+The filesystem on Kubernetes nodes mainly consists of the operating system, [container ephemeral storage][1], container images, and container logs.
+Since Kubelet automatically handles [cleaning up old logs][2] and [deleting unused images][3], container ephemeral storage is a common cause of this alert. Although this alert may be triggered before Kubelet's garbage collection kicks in.
+
+</details>
+
 ## Impact
 
 A filesystem running full is very bad for any process in need to write to the
@@ -60,3 +68,7 @@ Exit debug:
 $ exit
 $ exit
 ```
+
+[1]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage
+[2]: https://kubernetes.io/docs/concepts/cluster-administration/logging/
+[3]: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#containers-images


### PR DESCRIPTION
This PR does the following:

* Adds a readme, including guidelines mentioned in #9 
* Adds a collapsible section to many pages which contains a lot more details about some alerts. The section is collapsible since an experienced SRE would likely want to skip it, but a novice would click it if they need additional guidance.
* Expanded KubeletTooManyPods