### PR TITLE
etcdHighNumberOfFailedGRPCRequests.md: fix incorrect percentage description

### DIFF
--- a/content/runbooks/etcd/etcdHighNumberOfFailedGRPCRequests.md
+++ b/content/runbooks/etcd/etcdHighNumberOfFailedGRPCRequests.md
@@ -2,7 +2,7 @@
 
 ## Meaning
 
-This alert fires when at least 50% of etcd gRPC requests failed in the past 10
+This alert fires when at least 5% of etcd gRPC requests failed in the past 10
 minutes.
 
 ## Impact


### PR DESCRIPTION
In the promql expression, it's checking if the percentage value of failed requests is larger than 5.