### PR TITLE
docs: add annotation for duplicated metrics

### DIFF
--- a/content/runbooks/prometheus/PrometheusDuplicateTimestamps.md
+++ b/content/runbooks/prometheus/PrometheusDuplicateTimestamps.md
@@ -29,6 +29,6 @@ Now there is a judgement call to make, this could be the result of:
 
 * The target is reporting faulty data, sometimes this can be resolved by
   restarting the target, or it might need to be fixed in code of the offending
-  application.
+  application (for example, duplicated metrics with same labels).
 
 Further reading [blog](https://www.robustperception.io/debugging-out-of-order-samples)


### PR DESCRIPTION
After finding this error in https://github.com/NVIDIA/dcgm-exporter/releases/tag/3.3.5-3.4.0 which was later fixed, I've added this clarification in docs.