### PR TITLE
Update Submodule and Add nix shell capabilities

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,75 @@
+# Workflow for building and deploying a Hugo site to S3
+name: Deploy Hugo site to S3
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+# Sets permissions of the GITHUB_TOKEN to allow deployment to S3
+permissions:
+  contents: read
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "hugo_deploy"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: ${{ vars.HUGO_VERSION }}
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://GitHub.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb          
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "${{ vars.SITE_BASE_URL }}/"          
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4          
+        with:
+          name: hugo-site
+          path: ./public
+
+  # Deployment job
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifacts (Docker images) from previous workflows
+        uses: actions/download-artifact@v4
+        with:
+          name: hugo-site
+          path: ./public
+      - uses: promptlylabs/aws-auth-action@v1
+        with:
+          aws-profile: "tools"
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Sync to S3
+        id: deployment
+        run: aws s3 sync ./public/ s3://${{ vars.BUCKET_NAME }} --delete --cache-control max-age=31536000

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
-public/
-resources/
-.hugo_build.lock
+# Created by https://www.toptal.com/developers/gitignore/api/hugo
+# Edit at https://www.toptal.com/developers/gitignore?templates=hugo
+
+### Hugo ###
+# Generated files by hugo
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+
+# Executable may be added to repository
+hugo.exe
+hugo.darwin
+hugo.linux
+
+# Temporary lock file while building
+/.hugo_build.lock
+
+# End of https://www.toptal.com/developers/gitignore/api/hugo

--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,11 @@
-baseURL: "https://runbooks.prometheus-operator.dev"
+baseURL: "https://runbook.tools.internal.promptly.health/"
 languageCode: "en-us"
-title: "kube-prometheus runbooks"
+title: "Promptly alerts runbooks"
 
 theme: book
 
 params:
-  BookRepo: "https://github.com/prometheus-operator/runbooks"
+  BookRepo: "https://github.com/promptlylabs/runbooks"
   BookEditPath: "edit/main"
   BookSearch: true
   BookSection: "runbooks"

--- a/content/docs/add-runbook.md
+++ b/content/docs/add-runbook.md
@@ -83,6 +83,8 @@ The primary target for these runbooks are folks who are novices and don't have m
 
 To test your changes locally:
 
-1. Install [Hugo](https://gohugo.io/getting-started/installing/)
-2. Run `git submodule init` and `git submodule update` to clone the Hugo theme
-3. Run `hugo server` and navigate to http://localhost:1313/ in your browser
+1. Run `git submodule update --init --remote` to clone the Hugo theme.
+2. Either use [Nix](https://nixos.org/) or install required tools locally:
+   1. Install [Nix](https://nixos.org/download/) (command is `sh <(curl -L https://nixos.org/nix/install)` on MacOS) and run `nix-shell --run $SHELL` - first run will take a while.
+   2. Install [Hugo](https://gohugo.io/getting-started/installing/).
+3. Run `hugo server` and navigate to `http://localhost:1313/` in your browser

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
+  pkgs = import nixpkgs { config = {}; overlays = []; };
+in
+
+pkgs.mkShellNoCC {
+  packages = with pkgs; [
+    hugo
+  ];
+}


### PR DESCRIPTION
When following the steps on `content/docs/add-runbook.md`, the submodule is using an old version, that presents the following errors when running `hugo server`:

```shell
$ hugo server
Watching for changes in /Users/andregomes/Promptly/sandbox/prometheus-operator-runbooks/{archetypes,content,layouts,themes}
Watching for config changes in /Users/andregomes/Promptly/sandbox/prometheus-operator-runbooks/config.yaml
Start building sites … 
hugo v0.126.1+extended darwin/arm64 BuildDate=unknown VendorInfo=nixpkgs

ERROR render of "section" failed: "/Users/andregomes/Promptly/sandbox/prometheus-operator-runbooks/themes/book/layouts/_default/baseof.html:4:5": execute of template failed: template: _default/list.html:4:5: executing "_default/list.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:34:13: no such template "_internal/google_analytics_async.html"
ERROR render of "taxonomy" failed: "/Users/andregomes/Promptly/sandbox/prometheus-operator-runbooks/themes/book/layouts/_default/baseof.html:4:5": execute of template failed: template: taxonomy/taxonomy.html:4:5: executing "taxonomy/taxonomy.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:34:13: no such template "_internal/google_analytics_async.html"
ERROR render of "page" failed: "/Users/andregomes/Promptly/sandbox/prometheus-operator-runbooks/themes/book/layouts/_default/baseof.html:4:5": execute of template failed: template: _default/single.html:4:5: executing "_default/single.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:34:13: no such template "_internal/google_analytics_async.html"
Built in 129 ms
Error: error building site: render: failed to render pages: render of "home" failed: "/Users/andregomes/Promptly/sandbox/prometheus-operator-runbooks/themes/book/layouts/_default/baseof.html:4:5": execute of template failed: template: _default/list.html:4:5: executing "_default/list.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:34:13: no such template "_internal/google_analytics_async.html
```

The submodule was updated to the latest version, and the instructions on `content/docs/add-runbook.md` were also updated.

Nix is an option here, but it can be removed, since it is only installing Hugo.