### PR TITLE
feat: add subscription event postback processor battle cards

### DIFF
--- a/content/runbooks/general/SubscriptionEventPostbackProcessorTooMany5xxErrors.md
+++ b/content/runbooks/general/SubscriptionEventPostbackProcessorTooMany5xxErrors.md
@@ -1,0 +1,25 @@
+# SubscriptionEventPostbackProcessorTooMany5xxErrors
+
+## Meaning
+
+There is a high volume of non-trivial 5xx errors on `go-monorepo/SubscriptionEventPostbackProcessor` that are not expected
+
+
+<details>
+<summary>Full context</summary>
+
+HTTP 5xx errors usually happen when requests can’t be handled correctly, or take longer than a few seconds, due to some bug in the code or unavailability of one or more services that are required to complete some requests (i.e. databases, APIs, etc).
+
+</details>
+
+## Impact
+
+Since this repository is responsible for processing subscription events, a high volume of 5xx errors can mean that some subscription events are not being processed correctly. This can lead to not sending or delaying sending emails to users, which can impact the user experience.
+
+## Diagnosis
+
+Check the logs of the `go-monorepo/SubscriptionEventPostbackProcessor` to see if there are any errors that can explain the high volume of 5xx errors.
+
+## Mitigation
+
+If the 5xx errors started after a new deployment, try to rollback the deployment to the last stable version. Investigate the root cause of the issue and fix it before deploying again. If the 5xx errors are due to unavailability of a service, try to make the service more resilient by adding retries, timeouts, or circuit breakers.

--- a/content/runbooks/general/SubscriptionEventPostbackProcessorTooManyRestarts.md
+++ b/content/runbooks/general/SubscriptionEventPostbackProcessorTooManyRestarts.md
@@ -1,0 +1,25 @@
+# SubscriptionEventPostbackProcessorTooManyRestarts
+
+## Meaning
+
+There is a high volume of restarts on `go-monorepo/SubscriptionEventPostbackProcessor` that are not expected
+
+
+<details>
+<summary>Full context</summary>
+
+Restarts can happen for a variety of reasons, such as a crash, a manual restart, or a deployment. A high volume of restarts can indicate that the service is not stable. This can be due to a bug in the code, a misconfiguration, or a resource constraint.
+
+</details>
+
+## Impact
+
+Since this repository is responsible for processing subscription events, a high volume of restarts can mean that some subscription events are not being processed correctly. This can lead to not sending or delaying sending emails to users, which can impact the user experience.
+
+## Diagnosis
+
+To diagnose the issue, check the logs of the `go-monorepo/SubscriptionEventPostbackProcessor` to see if there are any errors that can explain the high volume of restarts, also check the deployment history to see if there are any recent deployments that could have caused the restarts.
+
+## Mitigation
+
+If the restarts started after a new deployment, try to rollback the deployment to the last stable version. Then investigate the root cause of the issue and fix it before deploying again.

--- a/content/runbooks/general/SubscriptionEventPotbackProcessorLatencyTooHigh.md
+++ b/content/runbooks/general/SubscriptionEventPotbackProcessorLatencyTooHigh.md
@@ -1,0 +1,24 @@
+# SubscriptionEventPotbackProcessorLatencyTooHigh
+
+## Meaning
+
+The alert means that the latency of the `go-monorepo/SubscriptionEventPostbackProcessor` is higher than expected.
+
+<details>
+<summary>Full context</summary>
+
+Latency is the time taken to process a request. High latency can be caused by a variety of reasons, such as a high volume of requests, a slow database, or a slow network connection. High latency can impact the user experience, as users may have to wait longer to receive emails from the service.
+
+</details>
+
+## Impact
+
+Since this repository is responsible for processing subscription events, high latency can mean that some subscription events are not being processed correctly. This can lead to not sending or delaying sending emails to users, which can impact the user experience.
+
+## Diagnosis
+
+To diagnose the issue, check the logs of the `go-monorepo/SubscriptionEventPostbackProcessor` to see if there are any errors that can explain the high latency. Also, check the deployment history to see if there are any recent deployments that could have caused the high latency. Timeouts, slow queries, or high CPU usage can be some of the reasons for high latency.
+
+## Mitigation
+
+If the high latency started after a new deployment, try to rollback the deployment to the last stable version. Investigate the root cause of the issue and fix it before deploying again. If the high latency is due to a high volume of requests, consider scaling the service horizontally or vertically to handle the load.


### PR DESCRIPTION
This PR adds 3 new battle cards to reference in their respective alerts of the subscription event postback processor server